### PR TITLE
Fix ARCamera.TrackingState with .relocalizing for Xcode 9.4

### DIFF
--- a/ios/ARKitInteraction/ARView+ARSCNViewDelegate.swift
+++ b/ios/ARKitInteraction/ARView+ARSCNViewDelegate.swift
@@ -141,6 +141,8 @@ extension ARCamera.TrackingState {
             return 3
         case .limited(.initializing):
             return 4
+        case .limited(.relocalizing):
+            return 5
         }
     }
     


### PR DESCRIPTION
Added missing case for relocalizing